### PR TITLE
Typo fixed and small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Work through some of the tutorials in the tutorial directory,
 evaluating each form at the REPL. You might start with:
 
 * hello_world.clj
+* binding.clj
+* building_queries.clj
 * social_news.clj
 * provenance.clj
 * datalog_on_defrecords.clj
 * data_functions.clj
-* binding.clj
 * graph.clj
 
 You can also run all of the examples and see their output by running:

--- a/tutorial/social_news.clj
+++ b/tutorial/social_news.clj
@@ -1,4 +1,4 @@
-;; work through at the REPL, evaulating each form
+;; work through at the REPL, evaluating each form
 
 (use 'datomic.samples.repl)
 


### PR DESCRIPTION
Fixed a typo on social_news, changed the order of some suggested examples and added the building_queries one as well. 

It'll be easier for users if they learn about bindings right after "hello world". Building queries should also be on the fundamentals, before the social news example that gets into more elaborate bits like retracting facts.